### PR TITLE
fix(home): correct a typo

### DIFF
--- a/home.html
+++ b/home.html
@@ -28,7 +28,7 @@
     target="_blank"
   >
   Digital Transformation - Next Generation System Configuration Tools</a>, published in the PACWorld Magazine December 2024 issue, has become available online.
-  It describes the IEC 61850 engineering process and at Transpower NZ and the related tools, which are essentially based on OpenSCD.
+  It describes the IEC 61850 engineering process at Transpower NZ and the related tools, which are essentially based on OpenSCD.
   <br>
   The authors are 
   <a


### PR DESCRIPTION
Removes an extra "and" from the topmost news item.